### PR TITLE
Added webservice-functions to mod_checkmark

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,32 @@
+<?php
+
+$functions = [
+
+        'mod_checkmark_get_checkmarks_by_courses' => [
+            'classname'     => 'mod_checkmark_external',
+            'methodname'    => 'get_checkmarks_by_courses',
+            'classpath'     => 'mod/checkmark/externallib.php',
+            'description'   => 'Get all checkmarks in the given courses',
+            'type'          => 'read',
+            'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_checkmark_get_checkmark' => [
+            'classname'     => 'mod_checkmark_external',
+            'methodname'    => 'get_checkmark',
+            'classpath'     => 'mod/checkmark/externallib.php',
+            'description'   => 'Get the checkmark with the given id',
+            'type'          => 'read',
+            'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_checkmark_submit' => [
+            'classname'     => 'mod_checkmark_external',
+            'methodname'    => 'submit',
+            'classpath'     => 'mod/checkmark/externallib.php',
+            'description'   => 'Submit a submission for the checkmark with the given id',
+            'type'          => 'write',
+            'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+];

--- a/externallib.php
+++ b/externallib.php
@@ -1,0 +1,374 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->libdir . '/externallib.php');
+require_once($CFG->dirroot . '/user/externallib.php');
+require_once($CFG->dirroot . '/mod/checkmark/locallib.php');
+
+class mod_checkmark_external extends external_api {
+
+    /**
+     * Returns description of the get_checkmarks_by_courses parameters
+     * @return external_function_parameters
+     */
+    public static function get_checkmarks_by_courses_parameters() {
+        return new external_function_parameters([
+            'courseids' => new external_multiple_structure(
+                new external_value(PARAM_INT, 'Course id'), 'Array of course ids (all enrolled courses if empty array)', VALUE_DEFAULT, []
+            ),
+        ]);
+    }
+
+    /**
+     * Returns description of the get_checkmarks_by_courses result value
+     * @return external_single_structure
+     */
+    public static function get_checkmarks_by_courses_returns() {
+        return new external_single_structure([
+            'checkmarks' => new external_multiple_structure(self::checkmark_structure(), 'All checkmarks for the given courses'),
+            'warnings' => new external_warnings()
+        ]);
+    }
+
+    /**
+     * Get all checkmarks for the courses with the given ids. If the ids are empty all checkmarks from all
+     * user-enrolled courses are returned.
+     *
+     * @param $courseids array the ids of the courses to get checkmarks for (all user enrolled courses if empty array)
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function get_checkmarks_by_courses($courseids) {
+        $warnings = new stdClass();
+
+        $params = self::validate_parameters(self::get_checkmarks_by_courses_parameters(), [
+            'courseids' => $courseids
+        ]);
+
+        $rcheckmarks = [];
+
+        $mycourses = new stdClass();
+        if (empty($params['courseids'])) {
+            $mycourses = enrol_get_my_courses();
+            $params['courseids'] = array_keys($mycourses);
+        }
+
+        // Ensure there are courseids to loop through.
+        if (!empty($params['courseids'])) {
+
+            list($courses, $warnings) = external_util::validate_courses($params['courseids'], $mycourses);
+
+            // Get the checkmarks in this course, this function checks users visibility permissions.
+            // We can avoid then additional validate_context calls.
+            $checkmark_instances = get_all_instances_in_courses("checkmark", $courses);
+            foreach ($checkmark_instances as $checkmark_instance) {
+
+                $checkmark = new checkmark($checkmark_instance->coursemodule);
+                $rcheckmarks[] = self::export_checkmark($checkmark);
+            }
+        }
+
+        $result = new stdClass();
+        $result->checkmarks = $rcheckmarks;
+        $result->warnings = $warnings;
+        return $result;
+    }
+
+    /**
+     * Returns description of the get_checkmark parameters
+     * @return external_function_parameters
+     */
+    public static function get_checkmark_parameters() {
+        return new external_function_parameters([
+            'checkmarkid' => new external_value(PARAM_INT, 'The id of the checkmark'),
+        ]);
+    }
+
+    /**
+     * Returns description of the get_checkmark result value
+     * @return external_single_structure
+     */
+    public static function get_checkmark_returns() {
+        return new external_single_structure([
+            'checkmark' => self::checkmark_structure(),
+        ]);
+    }
+
+    /**
+     * Returns the checkmark for the given id
+     *
+     * @throws restricted_context_exception
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws moodle_exception
+     * @throws required_capability_exception
+     * @throws invalid_parameter_exception
+     */
+    public static function get_checkmark($checkmarkid) {
+        $params = self::validate_parameters(self::get_checkmark_parameters(), ['checkmarkid' => $checkmarkid]);
+
+        $cm = get_coursemodule_from_instance('checkmark', $params['checkmarkid'], 0, false, MUST_EXIST);
+        $checkmark = new checkmark($cm->id);
+
+        $context = context_module::instance($checkmark->cm->id);
+        require_capability('mod/checkmark:view', $context);
+        self::validate_context($context);
+
+        $result = new stdClass();
+        $result->checkmark = self::export_checkmark($checkmark);
+        return $result;
+    }
+
+    /**
+     * Returns description of the submit parameters
+     * @return external_function_parameters
+     */
+    public static function submit_parameters() {
+        return new external_function_parameters([
+            'checkmarkid' => new external_value(PARAM_INT, 'The id of the checkmark'),
+            'submission_examples' => new external_multiple_structure(self::submit_example_structure(),
+                'The examples of the submission (must match the examples of the checkmark)'),
+        ]);
+    }
+
+    /**
+     * Returns description of the submit result value
+     * @return external_single_structure
+     */
+    public static function submit_returns() {
+        return new external_single_structure([
+            'checkmark' => self::checkmark_structure(),
+            'warnings' => new external_warnings()
+        ]);
+    }
+
+    /**
+     * Checks if the user can submit a checkmark and if the given submission_examples match the examples of the
+     * checkmark. Updates the submission of the checkmark and returns the checkmark
+     *
+     * @param $checkmarkid
+     * @param $submission_examples
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     * @throws required_capability_exception
+     * @throws restricted_context_exception
+     */
+    public static function submit($checkmarkid, $submission_examples) {
+        global $USER;
+        $params = self::validate_parameters(self::submit_parameters(), [
+            'checkmarkid' => $checkmarkid,
+            'submission_examples' => $submission_examples
+        ]);
+
+        $warnings = [];
+
+        $cm = get_coursemodule_from_instance('checkmark', $params['checkmarkid'], 0, false, MUST_EXIST);
+        $checkmark = new checkmark($cm->id);
+
+        $context = context_module::instance($checkmark->cm->id);
+        require_capability('mod/checkmark:view', $context);
+        self::validate_context($context);
+
+        $submission = $checkmark->get_submission();
+        $feedback = $checkmark->get_feedback();
+
+        // Guest can not submit nor edit an checkmark (bug: 4604)!
+        if (!is_enrolled($checkmark->context, $USER, 'mod/checkmark:submit')) {
+            $editable = false;
+        } else {
+            $editable = $checkmark->isopen() && (!$submission || $checkmark->checkmark->resubmit || ($feedback === false));
+        }
+
+        if (!$editable) {
+            print_error('nosubmissionallowed', 'checkmark');
+        }
+
+        // Create the submission if needed & return its id!
+        $submission = $checkmark->get_submission(0, true);
+
+        $example_counter = count($submission->get_examples());
+        foreach ($submission->get_examples() as $key => $example) {
+
+            $maybe_submission_example = null;
+            foreach ($params['submission_examples'] as $submission_example) {
+                if ($example->get_id() === $submission_example['id']) {
+                    $maybe_submission_example = $submission_example;
+                    $example_counter--;
+                    break;
+                }
+            }
+
+            if ($maybe_submission_example && isset($maybe_submission_example['checked']) && $maybe_submission_example['checked'] != 0) {
+                $submission->get_example($key)->set_state(\mod_checkmark\example::CHECKED);
+            } else {
+                $submission->get_example($key)->set_state(\mod_checkmark\example::UNCHECKED);
+            }
+
+        }
+
+        if ($example_counter !== 0) {
+            throw new InvalidArgumentException("Submission examples do not match the checkmark examples.");
+        }
+
+        $checkmark->update_submission($submission);
+        $checkmark->email_teachers($submission);
+
+        $result = new stdClass();
+        $result->checkmark = self::export_checkmark($checkmark);
+        $result->warnings = $warnings;
+        return $result;
+    }
+
+    /**
+     * Description of the checkmark structure in result values
+     * @return external_single_structure
+     */
+    private static function checkmark_structure() {
+        return new external_single_structure(
+            [
+                'id' => new external_value(PARAM_INT, 'checkmark id'),
+                'instance' => new external_value(PARAM_INT, 'checkmark instance id'),
+                'course' => new external_value(PARAM_INT, 'course id the checkmark belongs to'),
+                'name' => new external_value(PARAM_TEXT, 'checkmark name'),
+                'intro' => new external_value(PARAM_RAW, 'intro/description of the checkmark'),
+                'introformat' => new external_value(PARAM_INT, 'intro format'),
+                'timedue' => new external_value(PARAM_INT, 'time due of the checkmark'),
+                'cutoffdate' => new external_value(PARAM_INT, 'cutoff date of the checkmark'),
+                'submission_timecreated' => new external_value(PARAM_INT, 'submission created', VALUE_OPTIONAL),
+                'submission_timemodified' => new external_value(PARAM_INT, 'submission changed', VALUE_OPTIONAL),
+                'examples' => new external_multiple_structure(self::example_structure(), 'Examples'),
+                'feedback' => self::feedback_structure(),
+            ], 'example information'
+        );
+    }
+
+    /**
+     * Description of the feedback structure in result values
+     * @return external_single_structure
+     */
+    private static function feedback_structure() {
+        return new external_single_structure(
+            [
+                'grade' => new external_value(PARAM_TEXT, 'Grade'),
+                'feedback' => new external_value(PARAM_RAW, 'Feedback comment'),
+                'feedbackformat' => new external_value(PARAM_INT, 'Feedback comment format'),
+                'timecreated' => new external_value(PARAM_INT, 'Time the feedback was given'),
+                'timemodified' => new external_value(PARAM_INT, 'Time the feedback was modified'),
+            ], 'submission information',
+            VALUE_OPTIONAL
+        );
+    }
+
+    /**
+     * Description of the example structure in result values
+     * @return external_single_structure
+     */
+    private static function example_structure() {
+        return new external_single_structure(
+            [
+                'id' => new external_value(PARAM_INT, 'example id'),
+                'name' => new external_value(PARAM_TEXT, 'example name'),
+                'checked' => new external_value(PARAM_INT, 'example checked state', VALUE_OPTIONAL),
+            ], 'example information'
+        );
+    }
+
+    /**
+     * Description of the submit_example structure in parameters
+     * @return external_single_structure
+     */
+    private static function submit_example_structure() {
+        return new external_single_structure(
+            [
+                'id' => new external_value(PARAM_INT, 'example id'),
+                'name' => new external_value(PARAM_TEXT, 'example name', VALUE_OPTIONAL),
+                'checked' => new external_value(PARAM_INT, 'example checked state'),
+            ], 'example information'
+        );
+    }
+
+    /**
+     * Converts the given checkmark to match the checkmark structure for result values
+     *
+     * @param $checkmark checkmark  The checkmark to be exported
+     * @return object               The exported checkmark (conforms to the checkmark_structure)
+     * @throws dml_exception
+     */
+    private static function export_checkmark($checkmark) {
+        $result_checkmark = new stdClass();
+
+        $result_checkmark->id = $checkmark->cm->id;
+        $result_checkmark->instance = $checkmark->checkmark->id;
+        $result_checkmark->course = $checkmark->checkmark->course;
+        $result_checkmark->name = $checkmark->checkmark->name;
+        $result_checkmark->intro = $checkmark->checkmark->intro;
+        $result_checkmark->introformat = $checkmark->checkmark->introformat;
+        $result_checkmark->timedue = $checkmark->checkmark->timedue;
+        $result_checkmark->cutoffdate = $checkmark->checkmark->cutoffdate;
+
+        if ($checkmark->get_submission()) {
+            $result_checkmark->submission_timecreated = $checkmark->get_submission()->timecreated;
+            $result_checkmark->submission_timemodified = $checkmark->get_submission()->timemodified;
+            $result_checkmark->examples = self::export_examples($checkmark->get_submission()->get_examples(), true);
+        } else {
+            $result_checkmark->examples = self::export_examples($checkmark->get_examples());
+        }
+
+        if ($checkmark->get_feedback()) {
+            $result_checkmark->feedback = self::export_feedback($checkmark->get_feedback());
+        }
+
+        return $result_checkmark;
+    }
+
+    /**
+     * Converts the given examples to match the example structure for result values
+     *
+     * @param $examples \mod_checkmark\example[]    The examples to export
+     * @param false $export_checked Export the information if the example is checked by the user via a submission
+     * @return array                                The exported examples (conforms to the example_structure)
+     */
+    private static function export_examples($examples, $export_checked = false) {
+        $result_examples = [];
+        foreach ($examples as $example) {
+
+            $result_example = new stdClass();
+            $result_example->id = $example->get_id();
+            $result_example->name = $example->get_name();
+
+            if ($export_checked) {
+                $result_example->checked = $example->is_checked() ? 1 : 0;
+            }
+
+            $result_examples[] = $result_example;
+        }
+
+        return $result_examples;
+    }
+
+    /**
+     * Converts the given feedback to match the feedback structure for result values
+     *
+     * @param $feedback object  Feedback to be exported
+     * @return object           The exported feedback (conforms to the feedback_structure)
+     */
+    private static function export_feedback($feedback) {
+        $result_feedback = new stdClass();
+
+        $result_feedback->grade = $feedback->grade;
+        $result_feedback->feedback = $feedback->feedback;
+        $result_feedback->feedbackformat = $feedback->format;
+        $result_feedback->timecreated = $feedback->timecreated;
+        $result_feedback->timemodified = $feedback->timemodified;
+
+        return $result_feedback;
+    }
+
+}

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -1,0 +1,263 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/webservice/tests/helpers.php');
+require_once($CFG->dirroot . '/mod/checkmark/externallib.php');
+
+/**
+ * External mod checkmark functions unit tests
+ */
+class mod_checkmark_external_testcase extends externallib_advanced_testcase {
+
+    /**
+     * Test if the user only gets checkmarks for enrolled courses
+     */
+    public function test_get_checkmarks_by_courses() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course1 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse1',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course1->id);
+
+        $course2 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse2',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course2->id);
+
+        $course3 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse3',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $checkmark1 = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course1->id,
+            'name' => 'Checkmark Module 1',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $checkmark2 = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course2->id,
+            'name' => 'Checkmark Module 2',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $checkmark3 = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course3->id,
+            'name' => 'Checkmark Module 3',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_checkmark_external::get_checkmarks_by_courses([]);
+
+        // user is enrolled only in course1 and course2, so the third checkmark module in course3 should not be included
+        $this->assertEquals(2, count($result->checkmarks));
+    }
+
+    /**
+     * Test if the user gets a valid checkmark from the endpoint
+     */
+    public function test_get_checkmark() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $checkmark = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course->id,
+            'name' => 'Checkmark Module',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_checkmark_external::get_checkmark($checkmark->id);
+
+        // checkmark name should be equal to 'Checkmark Module'
+        $this->assertEquals('Checkmark Module', $result->checkmark->name);
+
+        // Course id in checkmark should be equal to the id of the course
+        $this->assertEquals($course->id, $result->checkmark->course);
+    }
+
+    /**
+     * Test if the user gets an exception when the checkmark is hidden in the course
+     */
+    public function test_get_checkmark_hidden() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $checkmark = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course->id,
+            'name' => 'Hidden Checkmark Module',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+            'visible' => 0,
+        ]);
+
+        $this->setUser($user);
+
+        // Test should throw require_login_exception
+        $this->expectException(require_login_exception::class);
+
+        $result = mod_checkmark_external::get_checkmark($checkmark->id);
+
+    }
+
+    /**
+     * Test the submission of a checkmark module
+     */
+    public function test_get_submit() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $checkmark = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course->id,
+            'name' => 'Checkmark Module',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_checkmark_external::get_checkmark($checkmark->id);
+
+        $submission_examples = [];
+        foreach ($result->checkmark->examples as $example) {
+            $submission_examples[] = ['id' => $example->id, 'checked' => $example->id % 2];
+        }
+
+        $result = mod_checkmark_external::submit($checkmark->id, $submission_examples);
+
+        // checkmark name should be equal to 'Checkmark Module'
+        $this->assertEquals('Checkmark Module', $result->checkmark->name);
+
+        // Course id in checkmark should be equal to the id of the course
+        $this->assertEquals($course->id, $result->checkmark->course);
+
+        // check the examples checked status of the result object
+        $this->assertEquals($result->checkmark->examples[0]->id % 2, $result->checkmark->examples[0]->checked);
+        $this->assertEquals($result->checkmark->examples[1]->id % 2, $result->checkmark->examples[1]->checked);
+        $this->assertEquals($result->checkmark->examples[2]->id % 2, $result->checkmark->examples[2]->checked);
+        $this->assertEquals($result->checkmark->examples[3]->id % 2, $result->checkmark->examples[3]->checked);
+        $this->assertEquals($result->checkmark->examples[4]->id % 2, $result->checkmark->examples[4]->checked);
+        $this->assertEquals($result->checkmark->examples[5]->id % 2, $result->checkmark->examples[5]->checked);
+        $this->assertEquals($result->checkmark->examples[6]->id % 2, $result->checkmark->examples[6]->checked);
+        $this->assertEquals($result->checkmark->examples[7]->id % 2, $result->checkmark->examples[7]->checked);
+        $this->assertEquals($result->checkmark->examples[8]->id % 2, $result->checkmark->examples[8]->checked);
+        $this->assertEquals($result->checkmark->examples[9]->id % 2, $result->checkmark->examples[9]->checked);
+
+        $result = mod_checkmark_external::get_checkmark($checkmark->id);
+
+        // checkmark name should be equal to 'Checkmark Module'
+        $this->assertEquals('Checkmark Module', $result->checkmark->name);
+
+        // Course id in checkmark should be equal to the id of the course
+        $this->assertEquals($course->id, $result->checkmark->course);
+
+        // check the examples checked status was correctly saved
+        $this->assertEquals($result->checkmark->examples[0]->id % 2, $result->checkmark->examples[0]->checked);
+        $this->assertEquals($result->checkmark->examples[1]->id % 2, $result->checkmark->examples[1]->checked);
+        $this->assertEquals($result->checkmark->examples[2]->id % 2, $result->checkmark->examples[2]->checked);
+        $this->assertEquals($result->checkmark->examples[3]->id % 2, $result->checkmark->examples[3]->checked);
+        $this->assertEquals($result->checkmark->examples[4]->id % 2, $result->checkmark->examples[4]->checked);
+        $this->assertEquals($result->checkmark->examples[5]->id % 2, $result->checkmark->examples[5]->checked);
+        $this->assertEquals($result->checkmark->examples[6]->id % 2, $result->checkmark->examples[6]->checked);
+        $this->assertEquals($result->checkmark->examples[7]->id % 2, $result->checkmark->examples[7]->checked);
+        $this->assertEquals($result->checkmark->examples[8]->id % 2, $result->checkmark->examples[8]->checked);
+        $this->assertEquals($result->checkmark->examples[9]->id % 2, $result->checkmark->examples[9]->checked);
+    }
+
+    /**
+     * Test if the user gets an exception if the submission is already closed ('cutofdate' was yesterday)
+     */
+    public function test_get_submit_negative() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $checkmark = self::getDataGenerator()->create_module('checkmark', [
+            'course' => $course->id,
+            'name' => 'Checkmark Module',
+            'intro' => 'Checkmark module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+            'cutoffdate' => time() - 60 * 60 * 24 // yesterday
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_checkmark_external::get_checkmark($checkmark->id);
+
+        $submission_examples = [];
+        foreach ($result->checkmark->examples as $example) {
+            $submission_examples[] = ['id' => $example->id, 'checked' => $example->id % 2];
+        }
+
+        // Test should throw moodle_exception because the 'cutofdate' was yesterday
+        $this->expectException(moodle_exception::class);
+
+        $result = mod_checkmark_external::submit($checkmark->id, $submission_examples);
+
+    }
+}


### PR DESCRIPTION
The Checkmark module can only be viewed with a browser. This PR solves
this problem by providing moodle webservice endpoints.
Currently only student-relevant endpoints are available as this is our
goal. However, the webservices can be extended easily.

To provide webservice functions for the mod_checkmark plugin following
additions were made:
- Added db/services.php which includes the description of the 3 endpoints
- Added tests/externallib_test.php which includes unit tests for the endpoints
- Added externallib.php which includes the actual endpoints.

Following endpoints were added:
- mod_checkmark_get_checkmarks_by_courses
- mod_checkmark_get_checkmark
- mod_checkmark_submit

_The collection of PRs posted by us, providing webservice functions, is supposed to serve the use-case of providing a student API for TUWEL (TU Wien Moodle Platform). It is with that purpose in mind, that we chose the plugins and the functionality to provide via web service. The following PRs are related to this effort:_
- [Checkmark](https://github.com/academic-moodle-cooperation/moodle-mod_checkmark/pull/65)
- [Grouptool](https://github.com/academic-moodle-cooperation/moodle-mod_grouptool/pull/23)
- [Offline-Quiz](https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/pull/151)
- [Organizer](https://github.com/academic-moodle-cooperation/moodle-mod_organizer/pull/97)
- [Publication](https://github.com/academic-moodle-cooperation/moodle-mod_publication/pull/51)