### PR TITLE
fix bug in `checkmark_supports()`

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2126,7 +2126,7 @@ function checkmark_supports($feature) {
             return MOD_PURPOSE_ASSESSMENT;
 
         default:
-            return false;
+            return null;
     }
 }
 


### PR DESCRIPTION
The function checkmark_supports is used to check if the activity module supports a particular feature. The function should return true if the feature is supported, false if it is not supported, null if the feature is unknown, or string for the module purpose for some features.

[Source](https://moodledev.io/docs/5.0/apis/plugintypes/mod#activity-module-support-functions)

The plugin is not shown in Moodle 5.0 and higher because activities are filtered based on "FEATURE_CAN_DISPLAY," which is true by default but not for this activity.